### PR TITLE
Fixed ingress resources and bad redirections

### DIFF
--- a/fitness-server/helm/templates/config-map.yaml
+++ b/fitness-server/helm/templates/config-map.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config-map
-  {{ include "fitness-server.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{ include "fitness-server.printSharedLabels" . | nindent 4 }}
 data:
-  SPRING_DATA_MONGODB_HOST: mongo-internal.default.svc.cluster.local
+  SPRING_DATA_MONGODB_HOST: k8s-mongo-internal-service
   SPRING_DATA_MONGODB_PORT: "27017"
   SPRING_DATA_MONGODB_DATABASE: fitness

--- a/fitness-server/helm/templates/deployment.yaml
+++ b/fitness-server/helm/templates/deployment.yaml
@@ -2,7 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-deployment
-  {{- include "fitness-server.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{- include "fitness-server.printSharedLabels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy: 
@@ -18,7 +19,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: {{ printf "%s:%s" .Values.docker.image .Values.docker.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: ["java"]
           args:
             - -jar
@@ -30,5 +31,5 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "0.5"
+              memory: {{ .Values.resources.requests.memory }}
+              cpu: {{ .Values.resources.requests.cpu }}

--- a/fitness-server/helm/templates/ingress.yaml
+++ b/fitness-server/helm/templates/ingress.yaml
@@ -4,8 +4,6 @@ metadata:
   name: {{ .Release.Name }}-ingress
   labels:
   {{- include "fitness-server.printSharedLabels" . | nindent 4 }}
-  # annotations:
-  #   nginx.ingress.kubernetes.io/rewrite-target: /api
 spec:
   ingressClassName: nginx
   rules:
@@ -17,4 +15,4 @@ spec:
               service:
                 name: {{ .Release.Name }}-internal-service
                 port:
-                  number: 8080
+                  number: 80

--- a/fitness-server/helm/templates/ingress.yaml
+++ b/fitness-server/helm/templates/ingress.yaml
@@ -3,18 +3,18 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   labels:
-  {{- include "fitness-ui.printSharedLabels" . | nindent 4 }}
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+  {{- include "fitness-server.printSharedLabels" . | nindent 4 }}
+  # annotations:
+  #   nginx.ingress.kubernetes.io/rewrite-target: /api
 spec:
   ingressClassName: nginx
   rules:
     - http:
         paths:
-          - path: /
+          - path: /api
             pathType: Prefix
             backend:
               service:
-                name: {{ .Release.Name }}-service
+                name: {{ .Release.Name }}-internal-service
                 port:
-                  number: 80
+                  number: 8080

--- a/fitness-server/helm/templates/service.yaml
+++ b/fitness-server/helm/templates/service.yaml
@@ -9,6 +9,6 @@ spec:
     app: fitness-server
   ports:
     - protocol: TCP
-      port: 8080
+      port: 80
       targetPort: 8080
   type: ClusterIP

--- a/fitness-server/helm/templates/service.yaml
+++ b/fitness-server/helm/templates/service.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-internal-service
-  {{- include "fitness-server.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{- include "fitness-server.printSharedLabels" . | nindent 4 }}
 spec:
   selector:
     app: fitness-server

--- a/fitness-server/helm/values.yaml
+++ b/fitness-server/helm/values.yaml
@@ -1,3 +1,9 @@
-clusterDomain: raspi.local
-docker:
-  image: irdcat/fitness-server
+clusterDomain: api.raspi.local
+image:
+  repository: "irdcat/fitness-server"
+  tag: "latest"
+
+resources:
+  requests:
+    memory: "500Mi"
+    cpu: "0.5"

--- a/fitness-ui/Dockerfile
+++ b/fitness-ui/Dockerfile
@@ -7,7 +7,13 @@ WORKDIR /home/node
 COPY package.json .
 RUN npm install --only=prod
 COPY . .
+ARG FITNESS_SERVER_URL
+ARG FITNESS_SERVER_PORT=80
+ENV FITNESS_SERVER_URL=${FITNESS_SERVER_URL}
+ENV FITNESS_SERVER_PORT=${FITNESS_SERVER_PORT}
 RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /home/node/build /usr/share/nginx/html
+# RUN cp /etc/nginx/conf.d/default.conf /nginx-default.conf.bak
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/fitness-ui/helm/templates/config-map.yaml
+++ b/fitness-ui/helm/templates/config-map.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-config-map
-  {{ include "fitness-ui.printSharedLabels" . | nindent 2 }}
-data:
-  FITNESS_SERVER_URL: "fitness-server-service.default.svc.cluster.local"
-  FITNESS_SERVER_PORT: "8080"

--- a/fitness-ui/helm/templates/deployment.yaml
+++ b/fitness-ui/helm/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   labels:
-    {{- include "fitness-ui.printSharedLabels" . | nindent 2 }}
+    {{- include "fitness-ui.printSharedLabels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy: 
@@ -20,17 +20,17 @@ spec:
     spec:
       containers:
         - name: ui
-          image: {{ printf "%s:%s" .Values.docker.image .Values.docker.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: ["nginx"]
           args:
             - -g
             - "daemon off;"
-          envFrom:
-            - configMapRef:
-                name: {{ .Release.Name }}-config-map
+          # envFrom:
+          #   - configMapRef:
+          #       name: {{ .Release.Name }}-config-map
           ports:
             - containerPort: 80
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "0.5"
+              memory: {{ .Values.resources.requests.memory }}
+              cpu: {{ .Values.resources.requests.cpu }}

--- a/fitness-ui/helm/templates/middleware.yaml
+++ b/fitness-ui/helm/templates/middleware.yaml
@@ -1,9 +1,0 @@
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  name: {{ .Release.Name }}-middleware
-spec:
-  stripPrefix:
-    forceSlash: false
-    prefixes:
-      - /fitness

--- a/fitness-ui/helm/templates/service.yaml
+++ b/fitness-ui/helm/templates/service.yaml
@@ -9,6 +9,6 @@ spec:
     app: fitness-ui
   ports:
   - name: http
-    port: 3333
+    port: 80
     targetPort: 80
-  type: LoadBalancer
+  type: ClusterIP

--- a/fitness-ui/helm/values.yaml
+++ b/fitness-ui/helm/values.yaml
@@ -1,3 +1,9 @@
 clusterDomain: raspi.local
-docker:
-  image: irdcat/fitness-ui
+image:
+  repository: m4tiqqq/fitness-ui
+  tag: latest
+
+resources:
+  requests:
+    memory: "500Mi"
+    cpu: "0.5"

--- a/fitness-ui/helm/values.yaml
+++ b/fitness-ui/helm/values.yaml
@@ -1,6 +1,6 @@
 clusterDomain: raspi.local
 image:
-  repository: m4tiqqq/fitness-ui
+  repository: irdcat/fitness-ui
   tag: latest
 
 resources:

--- a/fitness-ui/nginx.conf
+++ b/fitness-ui/nginx.conf
@@ -1,19 +1,12 @@
 server {
     listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
 
-    # Serve React App
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        # Check if the file exists; if not, serve index.html
         try_files $uri /index.html;
     }
 
-    # Proxy API requests
-    location /api/ {
-        proxy_pass http://127.0.0.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+    error_page 404 /index.html;
 }

--- a/fitness-ui/nginx.conf
+++ b/fitness-ui/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+
+    # Serve React App
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    # Proxy API requests
+    location /api/ {
+        proxy_pass http://127.0.0.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/k8s-mongo/helm/templates/external-service.yaml
+++ b/k8s-mongo/helm/templates/external-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.development true }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       targetPort: 27017
       nodePort: 32017
   type: NodePort
+{{- end }}

--- a/k8s-mongo/helm/templates/external-service.yaml
+++ b/k8s-mongo/helm/templates/external-service.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-external-service
-  {{- include "k8s-mongo.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{- include "k8s-mongo.printSharedLabels" . | nindent 4 }}
 spec:
   selector:
     app: mongo
@@ -10,4 +11,5 @@ spec:
     - protocol: TCP
       port: 27017
       targetPort: 27017
+      nodePort: 32017
   type: NodePort

--- a/k8s-mongo/helm/templates/internal-service.yaml
+++ b/k8s-mongo/helm/templates/internal-service.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-internal-service
-  {{- include "k8s-mongo.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{- include "k8s-mongo.printSharedLabels" . | nindent 4 }}
 spec:
   selector:
     app: mongo

--- a/k8s-mongo/helm/templates/persistent-volume.yaml
+++ b/k8s-mongo/helm/templates/persistent-volume.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ .Release.Name }}-persistent-volume
-  {{- include "k8s-mongo.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{- include "k8s-mongo.printSharedLabels" . | nindent 4 }}
 spec:
   capacity:
     storage: 20Gi

--- a/k8s-mongo/helm/templates/stateful-set.yaml
+++ b/k8s-mongo/helm/templates/stateful-set.yaml
@@ -2,7 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-stateful-set
-  {{- include "k8s-mongo.printSharedLabels" . | nindent 2 }}
+  labels:
+  {{- include "k8s-mongo.printSharedLabels" . | nindent 4 }}
 spec:
   serviceName: mongo-internal
   replicas: 1

--- a/k8s-mongo/helm/values.yaml
+++ b/k8s-mongo/helm/values.yaml
@@ -2,3 +2,4 @@ domain: raspi.local
 docker:
   image: mongo
   tag: latest
+development: false


### PR DESCRIPTION
Added ingress.yaml to fitness-server - react needs access to api from outside because it's rendered locally on user's machine so ingress had to be created to expose api

---
Changed Dockerfile for fitness-ui - added custom config for nginx to adjust the deployment for react.
Since react is built in docker image env variables are saved statically so env variables has to be set during docker image creation. There is build argument added for that (marked as required) called FITNESS_SERVER_URL.
Example command to build docker image:

docker build -t idrcat/fitness-ui:latest ./fitness-ui --build-arg FITNESS_SERVER_URL=http://localhost

Since everything is done locally it has to be set to localhost because it's hosted on local machine. If in the future it will be accessible through some public domain or hosted on another machine in local network FITNESS_SERVER_URL should be set to that domain/ip.

---
Fixed small bugs (ports, labels, service names)